### PR TITLE
short out extraneous information, such as quotes.

### DIFF
--- a/forums.js
+++ b/forums.js
@@ -128,6 +128,7 @@ function parseNewPosts(data) {
 }
 
 function parseQuotes(newPosts) {
+    return 0; 
     // start from top
     newPosts.each((key, jpost) => {
         let post = new Post(jpost);
@@ -160,7 +161,8 @@ function parseUniversalTags() {
             img.attr("src", `https://sci-oly.eggs.workers.dev/?u=${imgSrc}`);
         }
     });
-
+    
+    return 0;
     // hide tags
     let tags = $("dl.codebox");
     tags.each((key, rawTag) => {


### PR DESCRIPTION
The extension is creating doubling up of every single quote, causing problems. The quote is now an integrated feature into scioly.org, so this is useless now.